### PR TITLE
Add colab link to notebook. Fixes #3.

### DIFF
--- a/notebooks/summary_stats.ipynb
+++ b/notebooks/summary_stats.ipynb
@@ -704,6 +704,16 @@
   "cells": [
     {
       "cell_type": "markdown",
+      "metadata": {
+       "colab_type": "text",
+       "id": "view-in-github"
+      },
+      "source": [
+       "<a href=\"https://colab.research.google.com/github/MLforHealth/ORCHID/blob/main/notebooks/summary_stats.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+     },
+    {
+      "cell_type": "markdown",
       "source": [
         "# Organ Retrieval and Collection of Health Information for Donation (ORCHID)\n",
         "\n",


### PR DESCRIPTION
Quick pull request to address https://github.com/MLforHealth/ORCHID/issues/3. 

This update adds an "Open in Colab" link to the top of the [summary stats](https://github.com/MLforHealth/ORCHID/blob/main/notebooks/summary_stats.ipynb) Python notebook. Clicking the link opens the notebook in Colab.